### PR TITLE
Allow sending data asynchronously with celery

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,8 +26,8 @@ Example
 
     import analytical
 
-    analytical.Provider('googleanalytics', 'UA-XXXXXXX-1')
-    analytical.pageview({
+    provider = analytical.Provider('googleanalytics', 'UA-XXXXXXX-1')
+    provider.pageview({
         'dl': 'https://example.com',
         'dt': 'My Page Title',
         'ua': 'user-agent',             # User agent

--- a/analytical/tasks.py
+++ b/analytical/tasks.py
@@ -1,0 +1,55 @@
+"""Celery tasks for executing asynchronously"""
+import logging
+
+import requests
+from celery import shared_task
+
+
+DEFAULT_TIMEOUT = 3  # seconds
+
+log = logging.getLogger(__name__)  # noqa
+
+
+@shared_task
+def send_analytics_data(
+    url,
+    params=None,
+    data=None,
+    method="POST",
+    timeout=DEFAULT_TIMEOUT,
+    fail_silently=True,
+):  # pylint: disable=too-many-arguments
+    """
+    A celery task for sending data to analytics providers asynchronously
+
+    :param str url: the URL to send to
+    :param obj params: a dict of query params to send (for GET requests)
+    :param obj data: a dict of data to send (for POST, PUT requests)
+    :param str method: the HTTP method (eg. GET, POST, PUT, etc.)
+    :param int timeout: timeout for the request in seconds
+    :param bool fail_silently: whether the task should raise an exception or fail silently
+    :returns bool: ``True`` on success or ``False`` on error
+    :raises: only if ``fail_silently`` is ``False`` and an error occurs
+    """
+    log.debug("Sending data to analytics (%s), %s", url, params)
+    kwargs = {
+        "url": url,
+        "method": method,
+        "data": data,
+        "params": params,
+        "timeout": timeout,
+    }
+    try:
+        resp = requests.request(**kwargs)
+    except requests.Timeout:
+        log.warning("Timeout sending data")
+        if not fail_silently:
+            raise
+        return False
+
+    if resp and not resp.ok:
+        log.warning("Unknown error sending analytics data")
+        if not fail_silently:
+            resp.raise_for_status()
+        return False
+    return True

--- a/development-requirements.txt
+++ b/development-requirements.txt
@@ -1,4 +1,5 @@
 # Library itself
+celery
 requests
 six
 user-agents<1.2.0

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     author_email="dev@readthedocs.org",
     url="http://github.com/rtfd/analytical",
     packages=find_packages(exclude=["tests"]),
-    install_requires=["requests", "six", "user-agents"],
+    install_requires=["requests", "six", "user-agents", "celery"],
     license="MIT",
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     keywords="analytics donottrack privacy",


### PR DESCRIPTION
This change allows optionally sending data asynchronously with celery. The default is synchronous.

This makes the library rely on installing celery but the library can be used without actually using celery or setting up a data broker or anything.